### PR TITLE
Fix space/tab issue

### DIFF
--- a/scripts/SNPs/vcfTools.py
+++ b/scripts/SNPs/vcfTools.py
@@ -128,8 +128,8 @@ class VcfRecord:
 
 		#Flag that indicates if the sample is diploid.
 		dip_flag = False
- 		if len(parsed_genotype) == 3:
- 			dip_flag = True
+		if len(parsed_genotype) == 3:
+			dip_flag = True
 
 
 		parsed_genotype_list = [parsed_genotype,0,0,0,0]


### PR DESCRIPTION
Fix a tiny issue with 2 spaces in vcfTools.py, which prevent python running the code due to space/tab mixing